### PR TITLE
add build cli workflow

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -1,4 +1,4 @@
-name: Build CLI
+name: Build Artifact
 
 on:
   push:

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    name: Build CLI
+    name: Build CLI Artifact
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -41,4 +41,3 @@ jobs:
         with:
           name: ${{ matrix.output }}
           path: ${{ matrix.output }}
-          retention-days: 1

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -19,11 +19,11 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - os: ubuntu-latest
-            output: cli-linux
+            output: scout-cli-linux
           - os: windows-latest
-            output: cli-windows.exe
+            output: scout-cli-windows.exe
           - os: macos-latest
-            output: cli-macos
+            output: scout-cli-macos
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -1,0 +1,44 @@
+name: Build CLI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  # Optionally trigger on release
+#   release:
+#     types: [created]
+
+jobs:
+  build:
+    name: Build CLI
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            output: cli-linux
+          - os: windows-latest
+            output: cli-windows.exe
+          - os: macos-latest
+            output: cli-macos
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Compile CLI
+        run: deno compile --allow-read --allow-write --allow-env --allow-net --output ${{ matrix.output }} mod.ts
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.output }}
+          path: ${{ matrix.output }}
+          retention-days: 1

--- a/README.md
+++ b/README.md
@@ -15,28 +15,15 @@ cd scout-cli
 2. Install prerequisites:
 
 - [Install Deno](https://docs.deno.com/runtime/getting_started/installation/)
-- [Setup your development environment](https://docs.deno.com/runtime/getting_started/setup_your_environment/)
+- [Setup your development IDE environment](https://docs.deno.com/runtime/getting_started/setup_your_environment/)
 
-3. Install `scout-cli`:
-
-```bash
-deno install --allow-read --allow-write --allow-env --allow-net -n scout-cli mod.ts --global
-```
-
-> **Note**: If Deno isn't in your PATH, run:
->
-> ```bash
-> echo 'export PATH="$HOME/.deno/bin:$PATH"' >> ~/.zshrc
-> source ~/.zshrc
-> ```
-
-After you make updates to this repo locally and want to test the `scout-cli` you can run the following to replace your existing copy:
+3. Now you should be able to run the code locally:
 
 ```bash
-deno install --allow-read --allow-write --allow-env --allow-net -n scout-cli mod.ts --global -f
+deno task dev --get-workflow=workflow_id_123
 ```
 
-### Using CLI
+### Using `scout-cli`
 
 1. Download the appropriate executable for your system from the [Build Artifact workflow](https://github.com/scoutos/scout-cli/actions/workflows/build-artifact.yml). For this example we will download the `scout-cli-macos` artifact.
 2. Unzip the file then run the following commands to make the executable available on your system:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 `scout-cli` allows one to interact with and update Scout workflows via
 [CLI](https://en.wikipedia.org/wiki/Command-line_interface) commands.
 
-## Development
+## Local Development
 
 1. Clone and setup:
 
@@ -37,6 +37,20 @@ deno install --allow-read --allow-write --allow-env --allow-net -n scout-cli mod
 ```
 
 ### Using CLI
+
+1. Download the appropriate executable for your system from the [Build Artifact workflow](https://github.com/scoutos/scout-cli/actions/workflows/build-artifact.yml). For this example we will download the `scout-cli-macos` artifact.
+2. Unzip the file then run the following commands to make the executable available on your system:
+
+```bash
+# Give permissions to run on mac
+xattr -d com.apple.quarantine scout-cli-macos
+
+# Move & rename executable 
+sudo mv scout-cli-macos /usr/local/bin/scout-cli
+```
+
+3. Now you should be able to use `scout-cli` from your system!
+4. If you want to remove the cli you can run `sudo rm /usr/local/bin/scout-cli`.
 
 When you first use the cli tool, you will be asked to set your `apikey`. This should be the secret key found in "API Keys" section in the Scout dashboard settings panel. **Note**: You may have to grant the cli permissions to write, read, delete to your system. The api key will be stored in `~/.scout-cli/secrets.json`.
 

--- a/deno.json
+++ b/deno.json
@@ -5,7 +5,7 @@
   "tasks": {
     "lint": "deno lint",
     "format": "deno fmt",
-    "dev": "deno run --allow-read --allow-write --allow-env --allow-net mod.ts"
+    "dev": "deno run --allow-read --allow-write --allow-env --allow-net mod.ts \"$@\""
   },
   "fmt": {
     "semiColons": false,


### PR DESCRIPTION
Using [github workflow](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow) to upload executable artifact for `scout-cli`