### PR TITLE
GRO-1354: Update so permissions aren't needed 

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -46,6 +46,10 @@ jobs:
         env:
           DENO_DIR: ./temp/deno-dir
 
+      - name: Set executable permissions
+        if: runner.os != 'Windows'
+        run: chmod +x ${{ matrix.output }}
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Attemping different takes at setting up the binary in a way that the user doesnt have to chmod -x the file after install.